### PR TITLE
Added mock web responses for <object>/<id>.<json,xml>

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,6 +47,12 @@ You have access to all the registered mock responses through ShopifyAPI::Mock::R
     ShopifyAPI::Mock::Response.all   # => array of all registered responses
     ShopifyAPI::Mock::Response.clear # => clears all the currently registered responses
 
+You also have access to each Shopify object asset by it's `id` based on the ids in the fixtures.  If you are using the fixtures include in the gem, you can do
+    
+    product = ShopifyAPI::Product.find(632910392)
+
+and you'll get back the fixture product called `Ipod Nano 8GB`
+
 And you can register your own response:
     
     ShopifyAPI::Mock::Response.new(:get, "orders/1.xml", "response content")

--- a/shopify-mock.gemspec
+++ b/shopify-mock.gemspec
@@ -27,4 +27,5 @@ browser, or in the console.}
   s.add_dependency("rake", [">= 0.8.7"])
   s.add_dependency("shopify_api", [">= 1.2.5"])
   s.add_dependency("activesupport", [">= 3.0.0"])
+  s.add_dependency("libxml-ruby", [">= 0.8.3"])
 end

--- a/spec/shopify_api_spec.rb
+++ b/spec/shopify_api_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'xml' # libxml-ruby gem
 
 shared_examples "a collection" do
   let(:collection) { 
@@ -35,6 +36,42 @@ describe "ShopifyAPI objects" do
       it_behaves_like "a collection"
     end
     
+  end
+
+  # still to test
+  # :articles, :events, :fulfillments,:variants, :transactions :provinces, :images, :metafields,
+  # test find on classes which have ids
+  [:blogs, :comments, :countries,  :customers,  :orders, :pages, :products, 
+   :redirects, :themes, :webhooks].each do |o|
+    describe 'find by :id.json' do
+      it "find #{o}/:id.json should return a ShopifyAPI::#{o.to_s.singularize.classify} item with the right id" do
+        
+        clz = "ShopifyAPI::" << o.to_s.singularize.classify
+        clz = clz.constantize
+        
+        first_item = JSON.parse(ShopifyAPI::Mock::Fixture.find(o, :json).data)[o.to_s].first
+        found = clz.find(first_item['id'].to_i)
+        found.should be_a clz
+        found.id.should == first_item['id']
+      end
+    end
+    describe 'find by :id.xml' do
+      it "find #{o}/:id.xml should return a ShopifyAPI::#{o.to_s.singularize.classify} item with the right id" do
+        
+        # grab id from fixture which we'll use to compare with the actual results from find
+        fixture_xml = XML::Document.string(ShopifyAPI::Mock::Fixture.find(o, :xml).data)
+        finder = "//#{o.to_s}/#{o.to_s.singularize}/id"
+        first_item_id = fixture_xml.find_first(finder).content.to_i
+
+        clz = "ShopifyAPI::" << o.to_s.singularize.classify
+        clz = clz.constantize
+
+        found = clz.find(first_item_id)
+        found.should be_a clz
+        found.id.should == first_item_id
+      end
+    end
+
   end
 
   # still to test


### PR DESCRIPTION
Hey there

I needed this mock to work when i did stuff like
  ShopifyAPI::Product.find( product_id )

To do that, i needed new fake web responses for product/product_id.json or .xml
I've updated the gem to read all the fixture data and add those fake web responses based on the ids of the objects in the fixtures.  I only focused on collections and only top level collections (for example: assets which have themes are parents are not included). 

I also removed the failing test for assets (because it depends on a parent class theme) and replaced that test with a test for ShopifyAPI::Theme in your collections tests.

I've added tests for my additions.  I also updated the README to mention the fact that this is now supported.

Hope this pull request makes it in.

Keep up the good work.

Cheers
Mr Rogers (2rye.com)
