### PR TITLE
shopify oauth authentication sends token as X-Shopify-Access-Token header

### DIFF
--- a/lib/shopify-mock/urls.rb
+++ b/lib/shopify-mock/urls.rb
@@ -1,2 +1,2 @@
 # base URL used for registering mock responses
-SHOPIFY_MOCK_SHOP_BASE_URL = "https://.*:.*@.*\.myshopify.com/admin/"
+SHOPIFY_MOCK_SHOP_BASE_URL = "https://.*:?.*@?.*\.myshopify.com/admin/"


### PR DESCRIPTION
It now uses https://my-shop.myshopify.com/admin/ instead of https://a:b@my-shop.myshopify.com/admin/
