### PR TITLE
Updates URL regex to make : and @ optional

### DIFF
--- a/lib/shopify-mock/urls.rb
+++ b/lib/shopify-mock/urls.rb
@@ -1,2 +1,2 @@
 # base URL used for registering mock responses
-SHOPIFY_MOCK_SHOP_BASE_URL = "https://.*:.*@.*\.myshopify.com/admin/"
+SHOPIFY_MOCK_SHOP_BASE_URL = "https://.*:?.*@?.*\.myshopify.com/admin/"


### PR DESCRIPTION
With the regex as it currently stands, having a `:` and `@` are required in your shop name. I've never seen a username/password used as part of a shop name so I'm not sure why it would be required here. The examples in the README don't use it and when you try them you just get errors from ActiveResource: fakeweb doesn't capture the request (because the URL doesn't match) and it tries to go out to the internet for real. See issue #7 for the errors I was seeing.

By making the : and @ optional, the examples work just fine, but current shop names that happen to contain a username/password will continue to work.